### PR TITLE
Update athom-smart-plug.yaml to align with v2 plug config

### DIFF
--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -1,16 +1,25 @@
 substitutions:
   name: "athom-smart-plug-v3"
   friendly_name: "Athom Plug V3"
+  # Allows ESP device to be automatically lined to an 'Area' in Home Assistant. Typically used for areas such as 'Lounge Room', 'Kitchen' etc  
   room: ""
-  device_description: "athom esp32c3 smart plug"
+  device_description: "athom esp32-c3 smart plug"
   project_name: "Athom Technology.Smart Plug V3"
-  project_version: "ESP32C3"
+  # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
+  project_version: "v1.0"
   relay_restore_mode: RESTORE_DEFAULT_OFF
-  hidden_ssid: "false"
+  sensor_update_interval: 10s
+  # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
+  dns_domain: ""
+  # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
+  timezone: ""
+  # Enables faster network connections, with last connected SSID being connected to and no full scan for SSID being undertaken
+  wifi_fast_connect: "false"   
 
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
+  area: "${room}"  
   name_add_mac_suffix: true
   project:
     name: "${project_name}"
@@ -45,8 +54,12 @@ web_server:
   port: 80
 
 wifi:
-  fast_connect: ${hidden_ssid}
+  # This spawns an AP with the device name and mac address with no password.
   ap: {}
+  # Allow rapid re-connection to previously connect WiFi SSID, skipping scan of all SSID
+  fast_connect: "${wifi_fast_connect}"
+  # Define dns domain / suffix to add to hostname
+  domain: "${dns_domain}"
 
 captive_portal:
 
@@ -69,7 +82,8 @@ globals:
 binary_sensor:
   - platform: status
     name: "Status"
-
+    entity_category: diagnostic    
+    
   - platform: gpio
     pin:
       number: GPIO3
@@ -91,25 +105,44 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "Uptime Sensor"
+    entity_category: diagnostic
+    internal: True    
 
   - platform: wifi_signal
     name: "WiFi Signal"
+    id: wifi_signal_db
     update_interval: 60s
+    entity_category: diagnostic
+    internal: true
 
+  # Reports the WiFi signal strength in %
+  - platform: copy
+    source_id: wifi_signal_db
+    name: "WiFi Strength"
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "%"
+    entity_category: diagnostic
+
+    
   - platform: cse7766
-    update_interval: 5s
     current:
       name: "Current"
       filters:
+          - throttle_average: ${sensor_update_interval}
           - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
 
 
     voltage:
       name: "Voltage"
+      filters:
+          - throttle_average: ${sensor_update_interval}
+
     power:
       name: "Power"
       id: power_sensor
       filters:
+          - throttle_average: ${sensor_update_interval}
           - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
 
     energy:
@@ -117,8 +150,10 @@ sensor:
       id: energy
       unit_of_measurement: kWh
       filters:
+        - throttle_average: ${sensor_update_interval}
         # Multiplication factor from W to kW is 0.001
         - multiply: 0.001
+        - filter_out: nan
       on_value:
         then:
           - lambda: |-
@@ -136,8 +171,8 @@ sensor:
     accuracy_decimals: 3
     lambda: |-
       return id(total_energy);
-    update_interval: 10s
-
+    update_interval: ${sensor_update_interval}
+    
   - platform: total_daily_energy
     name: "Total Daily Energy"
     restore: true
@@ -152,10 +187,12 @@ button:
   - platform: factory_reset
     name: "Restart with Factory Default Settings"
     id: Reset
-
+    entity_category: config
+    
   - platform: safe_mode
     name: "Safe Mode"
     internal: false
+    entity_category: config    
 
 switch:
   - platform: gpio
@@ -177,11 +214,63 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      entity_category: diagnostic
     ssid:
       name: "Connected SSID"
+      entity_category: diagnostic
     mac_address:
       name: "Mac Address"
+      entity_category: diagnostic
 
+  #  Creates a sensor showing when the device was last restarted
+  - platform: template
+    name: 'Device Last Restart'
+    id: device_last_restart
+    icon: mdi:clock
+    entity_category: diagnostic
+#    device_class: timestamp
+
+  #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
+  - platform: template
+    name: "Device Uptime"
+    entity_category: diagnostic
+    lambda: |-
+      int seconds = (id(uptime_sensor).state);
+      int days = seconds / (24 * 3600);
+      seconds = seconds % (24 * 3600);
+      int hours = seconds / 3600;
+      seconds = seconds % 3600;
+      int minutes = seconds /  60;
+      seconds = seconds % 60;
+      if ( days > 3650 ) {
+        return { "Starting up" };
+      } else if ( days ) {
+        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else if ( hours ) {
+        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else if ( minutes ) {
+        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else {
+        return { (String(seconds) +"s").c_str() };
+      }
+    icon: mdi:clock-start
+    
 time:
   - platform: sntp
     id: sntp_time
+  # Define the timezone of the device
+    timezone: "${timezone}"
+  # Change sync interval from default 5min to 6 hours
+    update_interval: 360min    
+  # Publish the time the device was last restarted
+    on_time_sync:
+      then:
+        # Update last restart time, but only once.
+        - if:
+            condition:
+              lambda: 'return id(device_last_restart).state == "";'
+            then:
+              - text_sensor.template.publish:
+                  id: device_last_restart
+                  state: !lambda 'return id(sntp_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");'
+                  


### PR DESCRIPTION
Update v3 plug config to same configuration as used for the ESP8266 based v2 plug.

Comment: As there is no 'Discussion' feautre on the Repo, I'll see about updating v2 and/or v3 to reflect some common sense formatting to the sensor names. Currently the names such as Energy / Total Energy Daily / Total Energy or device related sensors such as Last Restart / Status / Uptime etc end up jumbled up in the web_server and Home Assistant views of the devices. Suggest these could be updated in naming so these are all grouped by their function and allow easy viewing (and logical naming when accessing in HA / writing automations/sensors that call them).

For example, here is the layout on my v2 plug:

Web Server:
![image](https://github.com/athom-tech/esp32-configs/assets/108674933/f86052a0-786c-493c-ad10-3383beabbd71)

Home Assistant:
![image](https://github.com/athom-tech/esp32-configs/assets/108674933/ca4cbabd-b793-41f1-9c7f-88ea686946c2)


