### PR TITLE
Update athom-smart-plug.yaml

### DIFF
--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -6,7 +6,7 @@ substitutions:
   device_description: "athom esp32-c3 smart plug"
   project_name: "Athom Technology.Smart Plug V3"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.1"
+  project_version: "v1.0.2"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
@@ -21,6 +21,7 @@ substitutions:
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
+  comment: "${device_description}"  
   area: "${room}"  
   name_add_mac_suffix: true
   project:
@@ -48,6 +49,8 @@ ota:
 
 logger:
   baud_rate: 0
+  logs:
+    component: ERROR # Fix for issue https://github.com/esphome/issues/issues/4717 "Component xxxxxx took a long time for an operation"  
 
 mdns:
   disabled: false


### PR DESCRIPTION
Missing the 'comment' entry that pulls the substitution 'device_description'. Add fix to logs to stop error that see's this message being created: "Component xxxxxx took a long time for an operation"

@tarontop @athom-tech for reduction of risk and potential liability, would it be better to set 'current_limit' in substitutions to be 10A instead of 16A? Whilst people 'should' be reading the documentation and changing this to reflect their countries limit, if this is not done, there is potential that 10A users will have this set by default to 16A, with possible damages and liability issues arising from it.

Same change should be looked at for the ESP8285 version of the Smart Plug.