### PR TITLE
Fix OTA for ESPHome 2024.6

### DIFF
--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""
   device_description: "athom esp32-c3 garage door opener"
   project_name: "Athom Technology.Garage Door Opener"
-  project_version: "v2.0.1"
+  project_version: "v2.0.2"
   dns_domain: ""
   timezone: ""
   wifi_fast_connect: "false"
@@ -14,6 +14,7 @@ esphome:
   friendly_name: "${friendly_name}"
   area: "${room}"
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -33,6 +34,7 @@ esp32:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -6,7 +6,7 @@ substitutions:
   device_description: "athom esp32-c3 smart plug"
   project_name: "Athom Technology.Smart Plug V3"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.1"
+  project_version: "v1.0.2"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
@@ -23,6 +23,7 @@ esphome:
   friendly_name: "${friendly_name}"
   area: "${room}"  
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -45,6 +46,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0


### PR DESCRIPTION
- Incremented all project versions by 0.0.1
- Added ESPHome "min_version" to all
- Added ota "platform" to all (required from ESPHome 2024.6.0)