### PR TITLE
Update athom-garage-door.yaml - SNTP Servers Defined

### DIFF
--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -1,13 +1,33 @@
 substitutions:
+  # Default name 
   name: "athom-garage-door"
+  # Default friendly name 
   friendly_name: "Athom Garage Door"
+  # Allows ESP device to be automatically linked to an 'Area' in Home Assistant. Typically used for areas such as 'Lounge Room', 'Kitchen' etc
   room: ""
+  # Description as appears in ESPHome & top of webserver page
   device_description: "athom esp32-c3 garage door opener"
+  # Project Name
   project_name: "Athom Technology.Garage Door Opener"
-  project_version: "v2.0.2"
+  # Project version denotes the release version of the yaml file, allowing checking of deployed vs latest version
+  project_version: "v2.0.3"
+  # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ""
+  # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
+  # Set the duration between the sntp service polling ntp.org servers for an update
+  sntp_update_interval: 6h
+  # Network time servers for your region, enter from lowest to highest priority. To use local servers update as per zones or countries at: https://www.ntppool.org/zone/@
+  sntp_server_1: "0.pool.ntp.org"
+  sntp_server_2: "1.pool.ntp.org"
+  sntp_server_3: "2.pool.ntp.org"    
+  # Enables faster network connections, with last connected SSID being connected to and no full scan for SSID being undertaken
   wifi_fast_connect: "false"
+  # Define logging level: NONE, ERROR, WARN, INFO, DEBUG (Default), VERBOSE, VERY_VERBOSE
+  log_level: "INFO"
+  # Enable or disable the use of IPv6 networking on the device
+  ipv6_enable: "false"
+
 
 esphome:
   name: "${name}"
@@ -37,12 +57,17 @@ ota:
   - platform: esphome
 
 logger:
+  level: ${log_level}
+  baud_rate: 0
 
 mdns:
   disabled: false
 
 web_server:
   port: 80
+
+network:
+  enable_ipv6: ${ipv6_enable}
 
 wifi:
   ap: {}
@@ -211,10 +236,19 @@ text_sensor:
 time:
   - platform: sntp
     id: sntp_time
+  # Define the timezone of the device
     timezone: "${timezone}"
-    update_interval: 360min    
+  # Change sync interval from default 5min to 6 hours (or as set in substitutions)
+    update_interval: ${sntp_update_interval}
+  # Set specific sntp servers to use
+    servers: 
+      - "${sntp_server_1}"
+      - "${sntp_server_2}"
+      - "${sntp_server_3}"   
+  # Publish the time the device was last restarted
     on_time_sync:
       then:
+        # Update last restart time, but only once.
         - if:
             condition:
               lambda: 'return id(device_last_restart).state == "";'


### PR DESCRIPTION
1) platform: sntp required sntp servers to be defined, this adds them using pool.ntp.org servers. Via substitutions this may be updated to use a pool server group specific to users location.
2) SNTP update interval changed to use a substitution, allowing users to easily change if they want more/less updating of time via sntp.
3) Log level able to be easily changed, via use of substitution.
4) Option to enable or disable (default) use of IPv6 added via substitutions.