### PR TITLE
BL0906 improvements

### DIFF
--- a/athom-energy-monitor-x2.yaml
+++ b/athom-energy-monitor-x2.yaml
@@ -168,34 +168,42 @@ sensor:
 
   - platform: bl0906
     update_interval: "${update_interval}"
-    Frequency:
+    frequency:
       name: 'Frequency'
       id: 'Frequency'
-    Temperature:
+    temperature:
       name: 'Temperature'
       id: 'Temperature'
-    Voltage:
+    voltage:
       name: 'Voltage'
       id: 'Voltage'
-    Current_1:
-      name: 'Current_1'
-      id: 'Current_1'
-    Current_2:
-      name: 'Current_2'
-      id: 'Current_2'
-    Power_1:
-      name: 'Power_1'
-      id: 'Power_1'
-    Power_2:
-      name: 'Power_2'
-      id: 'Power_2'
-    Energy_1:
-      id: 'Energy_1'
-    Energy_2:
-      id: 'Energy_2'
-    Energy_sum:
+    channel_1:
+      current:
+        name: 'Current_1'
+        id: 'Current_1'
+      power:
+        name: 'Power_1'
+        id: 'Power_1'
+      energy:
+        id: 'Energy_1'
+        name: 'Energy_1_Internal'
+        internal: true
+    channel_2:
+      current:
+        name: 'Current_2'
+        id: 'Current_2'
+      power:
+        name: 'Power_2'
+        id: 'Power_2'
+      energy:
+        id: 'Energy_2'
+        name: 'Energy_2_Internal'
+        internal: true
+    total_energy:
       id: 'Energy_sum'
-    Power_sum:
+      name: 'Energy_sum'
+      internal: true
+    total_power:
       name: 'Power_sum'
       id: 'Power_sum'
 

--- a/athom-energy-monitor-x6.yaml
+++ b/athom-energy-monitor-x6.yaml
@@ -224,66 +224,84 @@ sensor:
 
   - platform: bl0906
     update_interval: "${update_interval}"
-    Frequency:
+    frequency:
       name: 'Frequency'
       id: 'Frequency'
-    Temperature:
+    temperature:
       name: 'Temperature'
       id: 'Temperature'
-    Voltage:
+    voltage:
       name: 'Voltage'
       id: 'Voltage'
-    Current_1:
-      name: 'Current_1'
-      id: 'Current_1'
-    Current_2:
-      name: 'Current_2'
-      id: 'Current_2'
-    Current_3:
-      name: 'Current_3'
-      id: 'Current_3'
-    Current_4:
-      name: 'Current_4'
-      id: 'Current_4'
-    Current_5:
-      name: 'Current_5'
-      id: 'Current_5'
-    Current_6:
-      name: 'Current_6'
-      id: 'Current_6'
-    Power_1:
-      name: 'Power_1'
-      id: 'Power_1'
-    Power_2:
-      name: 'Power_2'
-      id: 'Power_2'
-    Power_3:
-      name: 'Power_3'
-      id: 'Power_3'
-    Power_4:
-      name: 'Power_4'
-      id: 'Power_4'
-    Power_5:
-      name: 'Power_5'
-      id: 'Power_5'
-    Power_6:
-      name: 'Power_6'
-      id: 'Power_6'
-    Energy_1:
-      id: 'Energy_1'
-    Energy_2:
-      id: 'Energy_2'
-    Energy_3:
-      id: 'Energy_3'
-    Energy_4:
-      id: 'Energy_4'
-    Energy_5:
-      id: 'Energy_5'
-    Energy_6:
-      id: 'Energy_6'
-    Energy_sum:
+    channel_1:
+      current:
+        name: 'Current_1'
+        id: 'Current_1'
+      power:
+        name: 'Power_1'
+        id: 'Power_1'
+      energy:
+        id: 'Energy_1'
+        name: 'Energy_1_Internal'
+        internal: true
+    channel_2:
+      current:
+        name: 'Current_2'
+        id: 'Current_2'
+      power:
+        name: 'Power_2'
+        id: 'Power_2'
+      energy:
+        id: 'Energy_2'
+        name: 'Energy_2_Internal'
+        internal: true
+    channel_3:
+      current:
+        name: 'Current_3'
+        id: 'Current_3'
+      power:
+        name: 'Power_3'
+        id: 'Power_3'
+      energy:
+        id: 'Energy_3'
+        name: 'Energy_3_Internal'
+        internal: true
+    channel_4:
+      current:
+        name: 'Current_4'
+        id: 'Current_4'
+      power:
+        name: 'Power_4'
+        id: 'Power_4'
+      energy:
+        id: 'Energy_4'
+        name: 'Energy_4_Internal'
+        internal: true
+    channel_5:
+      current:
+        name: 'Current_5'
+        id: 'Current_5'
+      power:
+        name: 'Power_5'
+        id: 'Power_5'
+      energy:
+        id: 'Energy_5'
+        name: 'Energy_5_Internal'
+        internal: true
+    channel_6:
+      current:
+        name: 'Current_6'
+        id: 'Current_6'
+      power:
+        name: 'Power_6'
+        id: 'Power_6'
+      energy:
+        id: 'Energy_6'
+        name: 'Energy_6_Internal'
+        internal: true
+    total_energy:
       id: 'Energy_sum'
-    Power_sum:
+    total_power:
       name: 'Power_sum'
       id: 'Power_sum'
 
@@ -373,7 +391,7 @@ sensor:
           {
             id(id_Energy_3_persist) = x;
           }
-          return id(id_Energy_3_persist);                    
+          return id(id_Energy_3_persist);
 
   - platform: copy
     name: 'Energy_4'

--- a/components/bl0906/bl0906.cpp
+++ b/components/bl0906/bl0906.cpp
@@ -4,91 +4,141 @@
 namespace esphome {
 namespace bl0906 {
 
-  static const char *const TAG = "bl0906";
-  uint8_t USR_WRPROT_Witable[6]={0xCA, 0x9E, 0x55, 0x55, 0x00, 0xB7};
-  uint8_t USR_WRPROT_Onlyread[6]={0xCA, 0x9E, 0x00, 0x00, 0x00, 0x61};
+static const char *const TAG = "bl0906";
+uint8_t USR_WRPROT_Witable[6] = {0xCA, 0x9E, 0x55, 0x55, 0x00, 0xB7};
+uint8_t USR_WRPROT_Onlyread[6] = {0xCA, 0x9E, 0x00, 0x00, 0x00, 0x61};
 
-  static const uint8_t BL0906_READ_COMMAND = 0x35;
-  static const uint8_t BL0906_WRITE_COMMAND = 0xCA;
+static const uint8_t BL0906_READ_COMMAND = 0x35;
+static const uint8_t BL0906_WRITE_COMMAND = 0xCA;
 
-  //Register address
-  //Voltage
-  static const uint8_t BL0906_V_RMS = 0x16;
+// Register address
+// Voltage
+static const uint8_t BL0906_V_RMS = 0x16;
 
-  //Total power
-  static const uint8_t BL0906_WATT_SUM = 0X2C;
+// Total power
+static const uint8_t BL0906_WATT_SUM = 0X2C;
 
-  //Current1~6
-  static const uint8_t BL0906_I_1_RMS = 0x0D;   //current_1
-  static const uint8_t BL0906_I_2_RMS = 0x0E;  
-  static const uint8_t BL0906_I_3_RMS = 0x0F;  
-  static const uint8_t BL0906_I_4_RMS = 0x10;  
-  static const uint8_t BL0906_I_5_RMS = 0x13;  
-  static const uint8_t BL0906_I_6_RMS = 0x14;   //current_6
+// Current1~6
+static const uint8_t BL0906_I_1_RMS = 0x0D;  // current_1
+static const uint8_t BL0906_I_2_RMS = 0x0E;
+static const uint8_t BL0906_I_3_RMS = 0x0F;
+static const uint8_t BL0906_I_4_RMS = 0x10;
+static const uint8_t BL0906_I_5_RMS = 0x13;
+static const uint8_t BL0906_I_6_RMS = 0x14;  // current_6
 
-  //Power1~6
-  static const uint8_t BL0906_WATT_1 = 0X23;    //power_1
-  static const uint8_t BL0906_WATT_2 = 0X24;
-  static const uint8_t BL0906_WATT_3 = 0X25;
-  static const uint8_t BL0906_WATT_4 = 0X26;
-  static const uint8_t BL0906_WATT_5 = 0X29;
-  static const uint8_t BL0906_WATT_6 = 0X2A;    //power_6
+// Power1~6
+static const uint8_t BL0906_WATT_1 = 0X23;  // power_1
+static const uint8_t BL0906_WATT_2 = 0X24;
+static const uint8_t BL0906_WATT_3 = 0X25;
+static const uint8_t BL0906_WATT_4 = 0X26;
+static const uint8_t BL0906_WATT_5 = 0X29;
+static const uint8_t BL0906_WATT_6 = 0X2A;  // power_6
 
-  //Active pulse count, unsigned
-  static const uint8_t BL0906_CF_1_CNT = 0X30;  //Channel_1
-  static const uint8_t BL0906_CF_2_CNT = 0X31;
-  static const uint8_t BL0906_CF_3_CNT = 0X32;
-  static const uint8_t BL0906_CF_4_CNT = 0X33;
-  static const uint8_t BL0906_CF_5_CNT = 0X36;
-  static const uint8_t BL0906_CF_6_CNT = 0X37;  //Channel_6
+// Active pulse count, unsigned
+static const uint8_t BL0906_CF_1_CNT = 0X30;  // Channel_1
+static const uint8_t BL0906_CF_2_CNT = 0X31;
+static const uint8_t BL0906_CF_3_CNT = 0X32;
+static const uint8_t BL0906_CF_4_CNT = 0X33;
+static const uint8_t BL0906_CF_5_CNT = 0X36;
+static const uint8_t BL0906_CF_6_CNT = 0X37;  // Channel_6
 
-  //Total active pulse count, unsigned
-  static const uint8_t BL0906_CF_SUM_CNT = 0X39;
+// Total active pulse count, unsigned
+static const uint8_t BL0906_CF_SUM_CNT = 0X39;
 
-  //Voltage frequency cycle
-  static const uint8_t BL0906_FREQUENCY = 0X4E;
+// Voltage frequency cycle
+static const uint8_t BL0906_FREQUENCY = 0X4E;
 
-  //Internal temperature
-  static const uint8_t BL0906_TEMPERATURE = 0X5E;
+// Internal temperature
+static const uint8_t BL0906_TEMPERATURE = 0X5E;
 
-  //Calibration register
-  //RMS gain adjustment register
-  static const uint8_t BL0906_RMSGN_1 = 0x6D;  //Channel_1
-  static const uint8_t BL0906_RMSGN_2 = 0x6E;
-  static const uint8_t BL0906_RMSGN_3 = 0x6F;
-  static const uint8_t BL0906_RMSGN_4 = 0x70;
-  static const uint8_t BL0906_RMSGN_5 = 0x73;
-  static const uint8_t BL0906_RMSGN_6 = 0x74;  //Channel_6
+// Calibration register
+// RMS gain adjustment register
+static const uint8_t BL0906_RMSGN_1 = 0x6D;  // Channel_1
+static const uint8_t BL0906_RMSGN_2 = 0x6E;
+static const uint8_t BL0906_RMSGN_3 = 0x6F;
+static const uint8_t BL0906_RMSGN_4 = 0x70;
+static const uint8_t BL0906_RMSGN_5 = 0x73;
+static const uint8_t BL0906_RMSGN_6 = 0x74;  // Channel_6
 
-  //RMS offset correction register
-  static const uint8_t BL0906_RMSOS_1 = 0x78;  //Channel_1
-  static const uint8_t BL0906_RMSOS_2 = 0x79;
-  static const uint8_t BL0906_RMSOS_3 = 0x7A;
-  static const uint8_t BL0906_RMSOS_4 = 0x7B;
-  static const uint8_t BL0906_RMSOS_5 = 0x7E;
-  static const uint8_t BL0906_RMSOS_6 = 0x7F;   //Channel_6
+// RMS offset correction register
+static const uint8_t BL0906_RMSOS_1 = 0x78;  // Channel_1
+static const uint8_t BL0906_RMSOS_2 = 0x79;
+static const uint8_t BL0906_RMSOS_3 = 0x7A;
+static const uint8_t BL0906_RMSOS_4 = 0x7B;
+static const uint8_t BL0906_RMSOS_5 = 0x7E;
+static const uint8_t BL0906_RMSOS_6 = 0x7F;  // Channel_6
 
-  //Active power gain adjustment register
-  static const uint8_t BL0906_WATTGN_1 = 0xB7;  //Channel_1
-  static const uint8_t BL0906_WATTGN_2 = 0xB8;
-  static const uint8_t BL0906_WATTGN_3 = 0xB9;
-  static const uint8_t BL0906_WATTGN_4 = 0xBA;
-  static const uint8_t BL0906_WATTGN_5 = 0xBD;
-  static const uint8_t BL0906_WATTGN_6 = 0xBE;  //Channel_6
-  
-void BL0906::loop() {}
+// Active power gain adjustment register
+static const uint8_t BL0906_WATTGN_1 = 0xB7;  // Channel_1
+static const uint8_t BL0906_WATTGN_2 = 0xB8;
+static const uint8_t BL0906_WATTGN_3 = 0xB9;
+static const uint8_t BL0906_WATTGN_4 = 0xBA;
+static const uint8_t BL0906_WATTGN_5 = 0xBD;
+static const uint8_t BL0906_WATTGN_6 = 0xBE;  // Channel_6
+
+void BL0906::loop() {
+  if (this->current_channel_ == UINT8_MAX) {
+    return;
+  }
+
+  while (this->available())
+    this->flush();
+
+  if (this->current_channel_ == 0) {
+    // Temperature
+    read_data(BL0906_TEMPERATURE, temperature_reference_, temperature_sensor_);
+  } else if (this->current_channel_ == 1) {
+    read_data(BL0906_I_1_RMS, current_reference_, current_sensor_1_);
+    read_data(BL0906_WATT_1, power_reference_, power_sensor_1_);
+    read_data(BL0906_CF_1_CNT, energy_reference_, energy_sensor_1_);
+  } else if (this->current_channel_ == 2) {
+    read_data(BL0906_I_2_RMS, current_reference_, current_sensor_2_);
+    read_data(BL0906_WATT_2, power_reference_, power_sensor_2_);
+    read_data(BL0906_CF_2_CNT, energy_reference_, energy_sensor_2_);
+  } else if (this->current_channel_ == 3) {
+    read_data(BL0906_I_3_RMS, current_reference_, current_sensor_3_);
+    read_data(BL0906_WATT_3, power_reference_, power_sensor_3_);
+    read_data(BL0906_CF_3_CNT, energy_reference_, energy_sensor_3_);
+  } else if (this->current_channel_ == 4) {
+    read_data(BL0906_I_4_RMS, current_reference_, current_sensor_4_);
+    read_data(BL0906_WATT_4, power_reference_, power_sensor_4_);
+    read_data(BL0906_CF_4_CNT, energy_reference_, energy_sensor_4_);
+  } else if (this->current_channel_ == 5) {
+    read_data(BL0906_I_5_RMS, current_reference_, current_sensor_5_);
+    read_data(BL0906_WATT_5, power_reference_, power_sensor_5_);
+    read_data(BL0906_CF_5_CNT, energy_reference_, energy_sensor_5_);
+  } else if (this->current_channel_ == 6) {
+    read_data(BL0906_I_6_RMS, current_reference_, current_sensor_6_);
+    read_data(BL0906_WATT_6, power_reference_, power_sensor_6_);
+    read_data(BL0906_CF_6_CNT, energy_reference_, energy_sensor_6_);
+  } else if (this->current_channel_ == UINT8_MAX - 2) {
+    // Frequency
+    read_data(BL0906_FREQUENCY, frequency_reference_, frequency_sensor_);
+    // Voltage
+    read_data(BL0906_V_RMS, voltage_reference_, voltage_sensor_);
+  } else if (this->current_channel_ == UINT8_MAX - 1) {
+    // Total power
+    read_data(BL0906_WATT_SUM, sum_power_reference_, power_sensor_sum_);
+    // Total Energy
+    read_data(BL0906_CF_SUM_CNT, sum_energy_reference_, energy_sensor_sum_);
+  } else {
+    this->current_channel_ = UINT8_MAX - 2;  // Go to frequency and voltage
+    return;
+  }
+  this->current_channel_++;
+}
 
 void BL0906::setup() {
   while (this->available())
-  this->flush();
-  this-> write_array(USR_WRPROT_Witable,sizeof(USR_WRPROT_Witable));
-//Calibration (1: register address; 2: value before calibration; 3: value after calibration)
-  Bias_correction(BL0906_RMSOS_1, 0.01600, 0);  //Calibration current_1
+    this->flush();
+  this->write_array(USR_WRPROT_Witable, sizeof(USR_WRPROT_Witable));
+  // Calibration (1: register address; 2: value before calibration; 3: value after calibration)
+  Bias_correction(BL0906_RMSOS_1, 0.01600, 0);  // Calibration current_1
   Bias_correction(BL0906_RMSOS_2, 0.01500, 0);
   Bias_correction(BL0906_RMSOS_3, 0.01400, 0);
   Bias_correction(BL0906_RMSOS_4, 0.01300, 0);
   Bias_correction(BL0906_RMSOS_5, 0.01200, 0);
-  Bias_correction(BL0906_RMSOS_6, 0.01200, 0);  //Calibration current_6
+  Bias_correction(BL0906_RMSOS_6, 0.01200, 0);  // Calibration current_6
 
   // gain_correction(BL0906_RMSGN_1, 2.15000, 2.148, BL0906_ki);   //RMS gain adjustment current_1
   // gain_correction(BL0906_RMSGN_2, 2.15100, 2.148, BL0906_ki);
@@ -103,207 +153,123 @@ void BL0906::setup() {
   // gain_correction(BL0906_WATTGN_4, 16.57646, 14.5, BL0906_Kp);
   // gain_correction(BL0906_WATTGN_5, 15.27440, 14.5, BL0906_Kp);
   // gain_correction(BL0906_WATTGN_6, 31.75744, 14.5, BL0906_Kp);  //Active power gain adjustment power_6
-  this-> write_array(USR_WRPROT_Onlyread,sizeof(USR_WRPROT_Onlyread));
+  this->write_array(USR_WRPROT_Onlyread, sizeof(USR_WRPROT_Onlyread));
 }
 
+void BL0906::update() { this->current_channel_ = 0; }
 
-void BL0906::update() {
-  while (this->available())
-  this->flush();
-//Frequency
-  read_data(BL0906_FREQUENCY, frequency_reference_, frequency_sensor_ );
-//Temperature
-  read_data(BL0906_TEMPERATURE, temperature_reference_, temperature_sensor_);
-//Voltage
-  read_data(BL0906_V_RMS, voltage_reference_, voltage_sensor_);
-//Current
-  read_data(BL0906_I_1_RMS, current_reference_, current_sensor_1_ );
-  read_data(BL0906_I_2_RMS, current_reference_, current_sensor_2_ );
-  read_data(BL0906_I_3_RMS, current_reference_, current_sensor_3_ );
-  read_data(BL0906_I_4_RMS, current_reference_, current_sensor_4_ );
-  read_data(BL0906_I_5_RMS, current_reference_, current_sensor_5_ );
-  read_data(BL0906_I_6_RMS, current_reference_, current_sensor_6_ );
-//Power
-  read_data(BL0906_WATT_1, power_reference_, power_sensor_1_ );
-  read_data(BL0906_WATT_2, power_reference_, power_sensor_2_ );
-  read_data(BL0906_WATT_3, power_reference_, power_sensor_3_ );
-  read_data(BL0906_WATT_4, power_reference_, power_sensor_4_ );
-  read_data(BL0906_WATT_5, power_reference_, power_sensor_5_ );
-  read_data(BL0906_WATT_6, power_reference_, power_sensor_6_ );
-//Total power
-  read_data(BL0906_WATT_SUM, sum_power_reference_, power_sensor_sum_ );
-//Energy
-  read_data(BL0906_CF_1_CNT, energy_reference_, energy_sensor_1_ );
-  read_data(BL0906_CF_2_CNT, energy_reference_, energy_sensor_2_ );
-  read_data(BL0906_CF_3_CNT, energy_reference_, energy_sensor_3_ );
-  read_data(BL0906_CF_4_CNT, energy_reference_, energy_sensor_4_ );
-  read_data(BL0906_CF_5_CNT, energy_reference_, energy_sensor_5_ );
-  read_data(BL0906_CF_6_CNT, energy_reference_, energy_sensor_6_ );
-//Total Energy
-  read_data(BL0906_CF_SUM_CNT, sum_energy_reference_, energy_sensor_sum_ );
-}
-
-//The SUM byte is (Addr+Data_L+Data_M+Data_H)&0xFF negated;
+// The SUM byte is (Addr+Data_L+Data_M+Data_H)&0xFF negated;
 uint8_t bl0906_checksum(const uint8_t address, const DataPacket *data) {
-  return (address + data->l + data->m + data->h) ^ 0xFF; 
+  return (address + data->l + data->m + data->h) ^ 0xFF;
 }
-  
-//Read data
-void BL0906::read_data(const uint8_t address, const float reference, sensor::Sensor *sensor_) {
+
+// Read data
+void BL0906::read_data(const uint8_t address, const float reference, sensor::Sensor *sensor) {
+  if (sensor == nullptr) {
+    return;
+  }
   DataPacket buffer;
   ube24_t data_u24;
   sbe24_t data_s24;
-  float value=0;
+  float value = 0;
 
-//Power
-  if (reference == power_reference_){
-    this-> write_byte(BL0906_READ_COMMAND);
-    this-> write_byte(address);
-    if (this-> read_array((uint8_t *) &buffer, sizeof(buffer)-1))  {      
-      if (bl0906_checksum(address,&buffer)==buffer.checksum) {
+  bool signed_result =
+      reference == temperature_reference_ || reference == sum_power_reference_ || reference == power_reference_;
+
+  this->write_byte(BL0906_READ_COMMAND);
+  this->write_byte(address);
+  if (this->read_array((uint8_t *) &buffer, sizeof(buffer) - 1)) {
+    if (bl0906_checksum(address, &buffer) == buffer.checksum) {
+      if (signed_result) {
         data_s24.l = buffer.l;
         data_s24.m = buffer.m;
         data_s24.h = buffer.h;
-        value = (float) to_int32_t(data_s24) * reference;
-        if (sensor_ != nullptr) {
-          sensor_->publish_state(value);
-        }      
-      }
-    } else {
-      ESP_LOGW(TAG, "Junk on wire. Throwing away partial power message");
-      while (read() >= 0)
-        ;
-    } 
-  }
-
-//Total power
-  if (reference == sum_power_reference_){
-    this-> write_byte(BL0906_READ_COMMAND);
-    this-> write_byte(address);
-    if (this-> read_array((uint8_t *) &buffer, sizeof(buffer)-1))  {      
-      if (bl0906_checksum(address,&buffer)==buffer.checksum) {
-        data_s24.l = buffer.l;
-        data_s24.m = buffer.m;
-        data_s24.h = buffer.h;
-        value = (float) to_int32_t(data_s24) * reference;
-        if (sensor_ != nullptr) {
-          sensor_->publish_state(value);
-        }      
-      }
-    } else {
-      ESP_LOGW(TAG, "Junk on wire. Throwing away partial power message");
-      while (read() >= 0)
-        ;
-    } 
-  }
-
-  //Voltage, current, power, total power
-  if (reference == voltage_reference_ || reference == current_reference_ || reference == energy_reference_ || reference == sum_energy_reference_) {
-    this-> write_byte(BL0906_READ_COMMAND);
-    this-> write_byte(address);
-    if (this-> read_array((uint8_t *) &buffer, sizeof(buffer)-1))  {    
-    //ESP_LOGW(TAG, "checksum= 0x%02X", bl0906_checksum(BL0906_V_RMS,&buffer));      
-      if (bl0906_checksum(address,&buffer)==buffer.checksum) {
+      } else {
         data_u24.l = buffer.l;
         data_u24.m = buffer.m;
         data_u24.h = buffer.h;
-        value = (float) to_uint32_t(data_u24) * reference;
-        if (sensor_ != nullptr) {
-          sensor_->publish_state(value);
-        }      
       }
     } else {
       ESP_LOGW(TAG, "Junk on wire. Throwing away partial message");
       while (read() >= 0)
         ;
-    }     
-  }  
-//Frequency
-  if (reference == frequency_reference_) {
-    this-> write_byte(BL0906_READ_COMMAND);
-    this-> write_byte(address);
-    if (this-> read_array((uint8_t *) &buffer, sizeof(buffer)-1))  {    
-      if (bl0906_checksum(address,&buffer)==buffer.checksum) {
-        data_u24.l = buffer.l;
-        data_u24.m = buffer.m;
-        data_u24.h = buffer.h;
-        value = reference / (float) to_uint32_t(data_u24);
-        if (sensor_ != nullptr) {
-          sensor_->publish_state(value);
-        }      
-      }
-    } else {
-      ESP_LOGW(TAG, "Junk on wire. Throwing frequency message");
-      while (read() >= 0)
-        ;
-    }     
+      return;
+    }
   }
-//Chip temperature
+  // Power
+  if (reference == power_reference_) {
+    value = (float) to_int32_t(data_s24) * reference;
+  }
+
+  // Total power
+  if (reference == sum_power_reference_) {
+    value = (float) to_int32_t(data_s24) * reference;
+  }
+
+  // Voltage, current, power, total power
+  if (reference == voltage_reference_ || reference == current_reference_ || reference == energy_reference_ ||
+      reference == sum_energy_reference_) {
+    value = (float) to_uint32_t(data_u24) * reference;
+  }
+
+  // Frequency
+  if (reference == frequency_reference_) {
+    value = reference / (float) to_uint32_t(data_u24);
+  }
+  // Chip temperature
   if (reference == temperature_reference_) {
-    this-> write_byte(BL0906_READ_COMMAND);
-    this-> write_byte(address);
-    if (this-> read_array((uint8_t *) &buffer, sizeof(buffer)-1))  {    
-      if (bl0906_checksum(address,&buffer)==buffer.checksum) {
-        data_s24.l = buffer.l;
-        data_s24.m = buffer.m;
-        data_s24.h = buffer.h;
-        value = (float) to_int32_t(data_s24);
-        value = (value - 64) *12.5/59-40;  
-        if (sensor_ != nullptr) {
-          sensor_->publish_state(value);
-        }      
-      }
-    } else {
-      ESP_LOGW(TAG, "Junk on wire. Throwing frequency message");
-      while (read() >= 0)
-        ;
-    }     
-  }  
+    value = (float) to_int32_t(data_s24);
+    value = (value - 64) * 12.5 / 59 - 40;
+  }
+  sensor->publish_state(value);
 }
-//RMS offset correction
+
+// RMS offset correction
 void BL0906::Bias_correction(const uint8_t address, const float measurements, const float Correction) {
   DataPacket data;
-  float ki = 12875*1*(5.1+5.1)*1000/2000/1.097; //Current coefficient
+  float ki = 12875 * 1 * (5.1 + 5.1) * 1000 / 2000 / 1.097;  // Current coefficient
   float I_RMS0 = measurements * ki;
   float I_RMS = Correction * ki;
-  int32_t value = (I_RMS*I_RMS-I_RMS0*I_RMS0) / 256; 
-  data.l = value << 24 >>24;
-  data.m = value << 16 >>24;
+  int32_t value = (I_RMS * I_RMS - I_RMS0 * I_RMS0) / 256;
+  data.l = value << 24 >> 24;
+  data.m = value << 16 >> 24;
   if (value < 0) {
-    data.h = (value << 8 >>24)|0b10000000;    
-  }  
+    data.h = (value << 8 >> 24) | 0b10000000;
+  }
   data.address = bl0906_checksum(address, &data);
-  ESP_LOGW(TAG, "RMSOS:%02X%02X%02X%02X%02X%02X",BL0906_WRITE_COMMAND,address,data.l ,data.m, data.h,data.address );
-  this-> write_byte(BL0906_WRITE_COMMAND);
-  this-> write_byte(address);
-  this-> write_byte(data.l);
-  this-> write_byte(data.m);
-  this-> write_byte(data.h);
-  this-> write_byte(data.address);
+  ESP_LOGW(TAG, "RMSOS:%02X%02X%02X%02X%02X%02X", BL0906_WRITE_COMMAND, address, data.l, data.m, data.h, data.address);
+  this->write_byte(BL0906_WRITE_COMMAND);
+  this->write_byte(address);
+  this->write_byte(data.l);
+  this->write_byte(data.m);
+  this->write_byte(data.h);
+  this->write_byte(data.address);
 }
-//Gain adjustment
-void BL0906::gain_correction(const uint8_t address, const float measurements, const float Correction, const float coefficient) {
-  DataPacket data;  
+// Gain adjustment
+void BL0906::gain_correction(const uint8_t address, const float measurements, const float Correction,
+                             const float coefficient) {
+  DataPacket data;
   float I_RMS0 = measurements * coefficient;
   float I_RMS = Correction * coefficient;
-  float rms_gn = int((I_RMS/I_RMS0-1) * 65536);
+  float rms_gn = int((I_RMS / I_RMS0 - 1) * 65536);
   int16_t value;
-  if (rms_gn <= -32767){
+  if (rms_gn <= -32767) {
     value = -32767;
   } else {
-    value = int(rms_gn);  
-  }  
+    value = int(rms_gn);
+  }
   data.h = 0xFF;
   data.m = value >> 8;
-  data.l = value << 8 >>8;  
+  data.l = value << 8 >> 8;
   data.address = bl0906_checksum(address, &data);
-  //ESP_LOGW(TAG, "RMSOS:%02X%02X%02X%02X%02X%02X",BL0906_WRITE_COMMAND,address,data.l ,data.m, data.h,data.address );
-  this-> write_byte(BL0906_WRITE_COMMAND);
-  this-> write_byte(address);
-  this-> write_byte(data.l);
-  this-> write_byte(data.m);
-  this-> write_byte(data.h);
-  this-> write_byte(data.address);
+  // ESP_LOGW(TAG, "RMSOS:%02X%02X%02X%02X%02X%02X",BL0906_WRITE_COMMAND,address,data.l ,data.m, data.h,data.address
+  // );
+  this->write_byte(BL0906_WRITE_COMMAND);
+  this->write_byte(address);
+  this->write_byte(data.l);
+  this->write_byte(data.m);
+  this->write_byte(data.h);
+  this->write_byte(data.address);
 }
 
 void BL0906::dump_config() {

--- a/components/bl0906/bl0906.h
+++ b/components/bl0906/bl0906.h
@@ -1,41 +1,50 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
 
 // https://www.belling.com.cn/media/file_object/bel_product/BL0906/datasheet/BL0906_V1.02_cn.pdf
 // https://www.belling.com.cn/media/file_object/bel_product/BL0906/guide/BL0906%20APP%20Note_V1.02.pdf
 
 namespace esphome {
 namespace bl0906 {
-  
-//Total power conversion
-static const float BL0906_WATT = 16*1.097*1.097*(20000+20000+20000+20000+20000)/(40.41259*((5.1+5.1)*1000/2000)*1*100*1*1000);
-//Total Energy conversion
-static const float BL0906_CF =16*4194304*0.032768*16/(3600000*16*(40.4125*((5.1+5.1)*1000/2000)*1*100*1*1000/(1.097*1.097*(20000+20000+20000+20000+20000))));
-//Frequency conversion
+
+// Total power conversion
+static const float BL0906_WATT = 16 * 1.097 * 1.097 * (20000 + 20000 + 20000 + 20000 + 20000) /
+                                 (40.41259 * ((5.1 + 5.1) * 1000 / 2000) * 1 * 100 * 1 * 1000);
+// Total Energy conversion
+static const float BL0906_CF = 16 * 4194304 * 0.032768 * 16 /
+                               (3600000 * 16 *
+                                (40.4125 * ((5.1 + 5.1) * 1000 / 2000) * 1 * 100 * 1 * 1000 /
+                                 (1.097 * 1.097 * (20000 + 20000 + 20000 + 20000 + 20000))));
+// Frequency conversion
 static const float BL0906_FREF = 10000000;
-//Temperature conversion    
-static const float BL0906_TREF = 12.5/59-40;
-//Current conversion
-static const float BL0906_IREF = 1.097/(12875*1*(5.1+5.1)*1000/2000);
-//Voltage conversion
-static const float BL0906_UREF = 1.097*(20000+20000+20000+20000+20000)/(13162*1*100*1000);
-//Power conversion
-static const float BL0906_PREF = 1.097*1.097*(20000+20000+20000+20000+20000)/(40.41259*((5.1+5.1)*1000/2000)*1*100*1*1000); 
-//Energy conversion
-static const float BL0906_EREF = 4194304*0.032768*16/(3600000*16*(40.4125*((5.1+5.1)*1000/2000)*1*100*1*1000/(1.097*1.097*(20000+20000+20000+20000+20000))));
-//Current coefficient
-static const float BL0906_ki = 12875*1*(5.1+5.1)*1000/2000/1.097;
-//Power coefficient
-static const float BL0906_Kp=40.4125*((5.1+5.1)*1000/2000)*1*100*1*1000/1.097/1.097/(20000+20000+20000+20000+20000);
+// Temperature conversion
+static const float BL0906_TREF = 12.5 / 59 - 40;
+// Current conversion
+static const float BL0906_IREF = 1.097 / (12875 * 1 * (5.1 + 5.1) * 1000 / 2000);
+// Voltage conversion
+static const float BL0906_UREF = 1.097 * (20000 + 20000 + 20000 + 20000 + 20000) / (13162 * 1 * 100 * 1000);
+// Power conversion
+static const float BL0906_PREF = 1.097 * 1.097 * (20000 + 20000 + 20000 + 20000 + 20000) /
+                                 (40.41259 * ((5.1 + 5.1) * 1000 / 2000) * 1 * 100 * 1 * 1000);
+// Energy conversion
+static const float BL0906_EREF = 4194304 * 0.032768 * 16 /
+                                 (3600000 * 16 *
+                                  (40.4125 * ((5.1 + 5.1) * 1000 / 2000) * 1 * 100 * 1 * 1000 /
+                                   (1.097 * 1.097 * (20000 + 20000 + 20000 + 20000 + 20000))));
+// Current coefficient
+static const float BL0906_ki = 12875 * 1 * (5.1 + 5.1) * 1000 / 2000 / 1.097;
+// Power coefficient
+static const float BL0906_Kp = 40.4125 * ((5.1 + 5.1) * 1000 / 2000) * 1 * 100 * 1 * 1000 / 1.097 / 1.097 /
+                               (20000 + 20000 + 20000 + 20000 + 20000);
 
 struct DataPacket {  // NOLINT(altera-struct-pack-align)
   uint8_t l;
   uint8_t m;
   uint8_t h;
-  uint8_t checksum;   // checksum
+  uint8_t checksum;  // checksum
   uint8_t address;
 } __attribute__((packed));
 
@@ -118,20 +127,23 @@ class BL0906 : public PollingComponent, public uart::UARTDevice {
   float current_reference_ = BL0906_IREF;
 
   float energy_reference_ = BL0906_EREF;
-  
+
   float frequency_reference_ = BL0906_FREF;
-  
+
   float temperature_reference_ = BL0906_TREF;
-    
+
   static uint32_t to_uint32_t(ube24_t input);
 
   static int32_t to_int32_t(sbe24_t input);
 
   void read_data(const uint8_t address, const float reference, sensor::Sensor *sensor_);
 
-  void Bias_correction(const uint8_t address, const float measurements, const float Correction) ; 
+  void Bias_correction(const uint8_t address, const float measurements, const float Correction);
 
-  void gain_correction(const uint8_t address, const float measurements, const float Correction, const float coefficient) ;
+  void gain_correction(const uint8_t address, const float measurements, const float Correction,
+                       const float coefficient);
+
+  uint8_t current_channel_ = 0;
 };
 }  // namespace bl0906
 }  // namespace esphome

--- a/components/bl0906/sensor.py
+++ b/components/bl0906/sensor.py
@@ -2,223 +2,140 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, uart
 from esphome.const import (
-    UNIT_PERCENT,
+    CONF_CHANNEL,
+    CONF_CURRENT,
+    CONF_ENERGY,
+    CONF_FREQUENCY,
     CONF_ID,
+    CONF_NAME,
+    CONF_POWER,
+    CONF_TEMPERATURE,
+    CONF_TOTAL_POWER,
+    CONF_VOLTAGE,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_FREQUENCY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_TOTAL,
+    UNIT_AMPERE,
+    UNIT_CELSIUS,
+    UNIT_HERTZ,
+    UNIT_KILOWATT_HOURS,
+    UNIT_VOLT,
+    UNIT_WATT,
 )
-
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["bl0906"]
+
+CONF_TOTAL_ENERGY = "total_energy"
 
 bl0906_ns = cg.esphome_ns.namespace("bl0906")
-BL0906 = bl0906_ns.class_(
-    "BL0906", cg.PollingComponent, uart.UARTDevice
-)
+BL0906 = bl0906_ns.class_("BL0906", cg.PollingComponent, uart.UARTDevice)
 
 CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(BL0906),
-            cv.Optional("Frequency"): sensor.sensor_schema(
-            accuracy_decimals = 0,
-            device_class = "frequency",
-            unit_of_measurement = "Hz"  
+            cv.Optional(CONF_FREQUENCY): sensor.sensor_schema(
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_FREQUENCY,
+                unit_of_measurement=UNIT_HERTZ,
             ),
-            cv.GenerateID(): cv.declare_id(BL0906),
-            cv.Optional("Temperature"): sensor.sensor_schema(
-            accuracy_decimals = 0,
-            device_class = "temperature",
-            unit_of_measurement = "°C"
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                unit_of_measurement=UNIT_CELSIUS,
             ),
-            cv.GenerateID(): cv.declare_id(BL0906),
-            cv.Optional("Voltage"): sensor.sensor_schema(
-            accuracy_decimals = 0,
-            device_class = "voltage",
-            unit_of_measurement = "V"  
+            cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                unit_of_measurement=UNIT_VOLT,
             ),
-            cv.Optional("Current_1"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "current",
-            unit_of_measurement = "A"  
+            cv.Optional(CONF_TOTAL_POWER): sensor.sensor_schema(
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_POWER,
+                unit_of_measurement=UNIT_WATT,
             ),
-            cv.Optional("Current_2"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "current",
-            unit_of_measurement = "A" 
-            ),
-            cv.Optional("Current_3"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "current",
-            unit_of_measurement = "A" 
-            ),
-            cv.Optional("Current_4"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "current",
-            unit_of_measurement = "A" 
-            ),
-            cv.Optional("Current_5"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "current",
-            unit_of_measurement = "A" 
-            ),
-            cv.Optional("Current_6"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "current",
-            unit_of_measurement = "A"  
-            ),
-            cv.Optional("Power_1"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "power",
-            unit_of_measurement = "W" 
-            ),
-            cv.Optional("Power_2"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "power",
-            unit_of_measurement = "W" 
-            ),
-            cv.Optional("Power_3"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "power",
-            unit_of_measurement = "W" 
-            ),
-            cv.Optional("Power_4"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "power",
-            unit_of_measurement = "W" 
-            ),
-            cv.Optional("Power_5"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "power",
-            unit_of_measurement = "W" 
-            ),
-            cv.Optional("Power_6"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "power",
-            unit_of_measurement = "W" 
-            ),
-            cv.Optional("Power_sum"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "power",
-            unit_of_measurement = "W" 
-            ),
-            cv.Optional("Energy_1"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "energy",
-            state_class = "total",  
-            unit_of_measurement = "kWh" 
-            ),
-            cv.Optional("Energy_2"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "energy",
-            state_class = "total",
-            unit_of_measurement = "kWh" ),
-            cv.Optional("Energy_3"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "energy",
-            state_class = "total",
-            unit_of_measurement = "kWh" 
-            ),
-            cv.Optional("Energy_4"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "energy",
-            state_class = "total",
-            unit_of_measurement = "kWh" 
-            ),
-            cv.Optional("Energy_5"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "energy",
-            state_class = "total",
-            unit_of_measurement = "kWh" 
-            ),            
-            cv.Optional("Energy_6"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "energy",
-            state_class = "total",
-            unit_of_measurement = "kWh" 
-            ),
-            cv.Optional("Energy_sum"): sensor.sensor_schema(
-            accuracy_decimals = 3,
-            device_class = "energy",
-            state_class = "total",
-            unit_of_measurement = "kWh" 
+            cv.Optional(CONF_TOTAL_ENERGY): sensor.sensor_schema(
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL,
+                unit_of_measurement=UNIT_KILOWATT_HOURS,
             ),
         }
+    )
+    .extend(
+        cv.Schema(
+            {
+                cv.Optional(f"{CONF_CHANNEL}_{i+1}"): cv.Schema(
+                    {
+                        cv.Optional(CONF_CURRENT): cv.maybe_simple_value(
+                            sensor.sensor_schema(
+                                accuracy_decimals=3,
+                                device_class=DEVICE_CLASS_CURRENT,
+                                unit_of_measurement=UNIT_AMPERE,
+                            ),
+                            key=CONF_NAME,
+                        ),
+                        cv.Optional(CONF_POWER): cv.maybe_simple_value(
+                            sensor.sensor_schema(
+                                accuracy_decimals=0,
+                                device_class=DEVICE_CLASS_POWER,
+                                unit_of_measurement=UNIT_WATT,
+                            ),
+                            key=CONF_NAME,
+                        ),
+                        cv.Optional(CONF_ENERGY): cv.maybe_simple_value(
+                            sensor.sensor_schema(
+                                accuracy_decimals=3,
+                                device_class=DEVICE_CLASS_ENERGY,
+                                unit_of_measurement=UNIT_KILOWATT_HOURS,
+                            ),
+                            key=CONF_NAME,
+                        ),
+                    }
+                )
+                for i in range(6)
+            }
+        )
     )
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.polling_component_schema("60s"))
 )
 
+
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    if "Frequency" in config:
-        sens = await sensor.new_sensor(config["Frequency"])
+    if frequency_config := config.get(CONF_FREQUENCY):
+        sens = await sensor.new_sensor(frequency_config)
         cg.add(var.set_frequency_sensor(sens))
-    if "Temperature" in config:
-        sens = await sensor.new_sensor(config["Temperature"])
-        cg.add(var.set_temperature_sensor(sens))    
-    if "Voltage" in config:
-        sens = await sensor.new_sensor(config["Voltage"])
+    if temperature_config := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature_config)
+        cg.add(var.set_temperature_sensor(sens))
+    if voltage_config := config.get(CONF_VOLTAGE):
+        sens = await sensor.new_sensor(voltage_config)
         cg.add(var.set_voltage_sensor(sens))
-    if "Current_1" in config:
-        sens = await sensor.new_sensor(config["Current_1"])
-        cg.add(var.set_current_sensor_1(sens))  
-    if "Current_2" in config:
-        sens = await sensor.new_sensor(config["Current_2"])
-        cg.add(var.set_current_sensor_2(sens))  
-    if "Current_3" in config:
-        sens = await sensor.new_sensor(config["Current_3"])
-        cg.add(var.set_current_sensor_3(sens))  
-    if "Current_4" in config:
-        sens = await sensor.new_sensor(config["Current_4"])
-        cg.add(var.set_current_sensor_4(sens))  
-    if "Current_5" in config:
-        sens = await sensor.new_sensor(config["Current_5"])
-        cg.add(var.set_current_sensor_5(sens))  
-    if "Current_6" in config:
-        sens = await sensor.new_sensor(config["Current_6"])
-        cg.add(var.set_current_sensor_6(sens))
-    if "Power_1" in config:
-        sens = await sensor.new_sensor(config["Power_1"])
-        cg.add(var.set_power_sensor_1(sens))  
-    if "Power_2" in config:
-        sens = await sensor.new_sensor(config["Power_2"])
-        cg.add(var.set_power_sensor_2(sens))  
-    if "Power_3" in config:
-        sens = await sensor.new_sensor(config["Power_3"])
-        cg.add(var.set_power_sensor_3(sens))  
-    if "Power_4" in config:
-        sens = await sensor.new_sensor(config["Power_4"])
-        cg.add(var.set_power_sensor_4(sens))  
-    if "Power_5" in config:
-        sens = await sensor.new_sensor(config["Power_5"])
-        cg.add(var.set_power_sensor_5(sens))        
-    if "Power_6" in config:
-        sens = await sensor.new_sensor(config["Power_6"])
-        cg.add(var.set_power_sensor_6(sens))  
-    if "Power_sum" in config:
-        sens = await sensor.new_sensor(config["Power_sum"])
-        cg.add(var.set_power_sensor_sum(sens))           
-    if "Energy_1" in config:
-        sens = await sensor.new_sensor(config["Energy_1"])
-        cg.add(var.set_energy_sensor_1(sens)) 
-    if "Energy_2" in config:
-        sens = await sensor.new_sensor(config["Energy_2"])
-        cg.add(var.set_energy_sensor_2(sens)) 
-    if "Energy_3" in config:
-        sens = await sensor.new_sensor(config["Energy_3"])
-        cg.add(var.set_energy_sensor_3(sens)) 
-    if "Energy_4" in config:
-        sens = await sensor.new_sensor(config["Energy_4"])
-        cg.add(var.set_energy_sensor_4(sens)) 
-    if "Energy_5" in config:
-        sens = await sensor.new_sensor(config["Energy_5"])
-        cg.add(var.set_energy_sensor_5(sens)) 
-    if "Energy_6" in config:
-        sens = await sensor.new_sensor(config["Energy_6"])
-        cg.add(var.set_energy_sensor_6(sens))         
-    if "Energy_sum" in config:
-        sens = await sensor.new_sensor(config["Energy_sum"])
-        cg.add(var.set_energy_sensor_sum(sens))   
-     
+
+    for i in range(8):
+        if channel_config := config.get(f"{CONF_CHANNEL}_{i+1}"):
+            if current_config := channel_config.get(CONF_CURRENT):
+                sens = await sensor.new_sensor(current_config)
+                cg.add(getattr(var, f"set_current_sensor_{i+1}")(sens))
+            if power_config := channel_config.get(CONF_POWER):
+                sens = await sensor.new_sensor(power_config)
+                cg.add(getattr(var, f"set_power_sensor_{i+1}")(sens))
+            if energy_config := channel_config.get(CONF_ENERGY):
+                sens = await sensor.new_sensor(energy_config)
+                cg.add(getattr(var, f"set_energy_sensor_{i+1}")(sens))
+
+    if total_power_config := config.get(CONF_TOTAL_POWER):
+        sens = await sensor.new_sensor(total_power_config)
+        cg.add(var.set_power_sensor_sum(sens))
+
+    if total_energy_config := config.get(CONF_TOTAL_ENERGY):
+        sens = await sensor.new_sensor(total_energy_config)
+        cg.add(var.set_energy_sensor_sum(sens))


### PR DESCRIPTION
Instead of Current_1 / Power_1 / Energy_1 in config, a user can now have a structured approach:
```yaml
channel_1:
  current: Current 1
  power: Power 1
  energy: Energy 1
```

The `current` / `power` / `energy` keys in yaml can still be used as full sensor schemas and fields can be overridden in yaml.

I also tidied up the actual c++ code, de-duplicating a lot of the same code, and also splitting the reads so it only reads 1 channel per `loop`. 
It will also only read the data for a sensor if that sensor is configured by the user now and doesn't waste time getting info unnecessarily.