### PR TITLE
Smart plug: add ID for power button

### DIFF
--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -120,6 +120,7 @@ binary_sensor:
       mode: INPUT_PULLUP
       inverted: true
     name: "Power Button"
+    id: power_button
     disabled_by_default: true
     on_multi_click:
       - timing:


### PR DESCRIPTION
Setting an ID for the power button allows its behavior to be extended or modified by configuration that uses this package, for example:

    packages:
      Athom_Technology.Smart_Plug_V2: github://athom-tech/athom-configs/athom-smart-plug-v2.yaml

    binary_sensor:
      - id: !extend power_button # Additional settings here