### PR TITLE
Update dns_domain: from "" to ".local"

### DIFF
--- a/athom-2ch-relay-board.yaml
+++ b/athom-2ch-relay-board.yaml
@@ -4,10 +4,10 @@ substitutions:
   room: ""
   device_description: "athom esp32 2ch relay board"
   project_name: "Athom Technology.ESP32 2CH Relay Board"
-  project_version: "v2.0.3"
+  project_version: "v2.0.4"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-4ch-relay-board.yaml
+++ b/athom-4ch-relay-board.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""
   device_description: "athom esp32 4ch relay board"
   project_name: "Athom Technology.ESP32 4CH Relay Board"
-  project_version: "v2.0.3"
+  project_version: "v2.0.4"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"

--- a/athom-4ch-relay-board.yaml
+++ b/athom-4ch-relay-board.yaml
@@ -7,7 +7,7 @@ substitutions:
   project_version: "v2.0.3"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-8ch-relay-board.yaml
+++ b/athom-8ch-relay-board.yaml
@@ -4,10 +4,10 @@ substitutions:
   room: ""
   device_description: "athom esp32 8ch relay board"
   project_name: "Athom Technology.ESP32 8CH Relay Board"
-  project_version: "v2.0.3"
+  project_version: "v2.0.4"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-energy-monitor-x2.yaml
+++ b/athom-energy-monitor-x2.yaml
@@ -5,10 +5,10 @@ substitutions:
   room: ""
   device_description: "athom bl0906 energy meter (2 channels)"
   project_name: "Athom Technology.Athom Energy Meter(2 Channels)"
-  project_version: "2.0.4"
+  project_version: "2.0.5"
   update_interval: 5s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-energy-monitor-x6.yaml
+++ b/athom-energy-monitor-x6.yaml
@@ -5,10 +5,10 @@ substitutions:
   room: ""
   device_description: "athom bl0906 energy meter (6 channels)"
   project_name: "Athom Technology.Athom Energy Meter(6 Channels)"
-  project_version: "2.0.4"
+  project_version: "2.0.5"
   update_interval: 5s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -10,9 +10,9 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Garage Door Opener"
   # Project version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v2.0.3"
+  project_version: "v2.0.4"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-mini-relay-v2.yaml
+++ b/athom-mini-relay-v2.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Mini Relay V2"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v2.0.3"
+  project_version: "v2.0.4"
    # Restore the relay (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_OFF
   # Set the update interval for sensors
@@ -18,7 +18,7 @@ substitutions:
   # Current Limit in Amps.
   current_limit : "10"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-presence-sensor-v3.yaml
+++ b/athom-presence-sensor-v3.yaml
@@ -10,9 +10,9 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom PS01C3 Presence Sensor"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.1"
+  project_version: "v3.0.2"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Smart Plug V3"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.6"
+  project_version: "v1.0.7"
    # Restore the relay (GPO switch) upon reboot to state:
   relay_restore_mode: RESTORE_DEFAULT_ON
   # Set the update interval for sensors
@@ -18,7 +18,7 @@ substitutions:
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
   current_limit : "16"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -11,7 +11,7 @@ substitutions:
   project_name: "Athom Technology.Smart Plug V3"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
   project_version: "v1.0.7"
-   # Restore the relay (GPO switch) upon reboot to state:
+  # Restore the relay (GPO switch) upon reboot to state:
   relay_restore_mode: RESTORE_DEFAULT_ON
   # Set the update interval for sensors
   sensor_update_interval: 10s

--- a/athom-zigbee-gateway.yaml
+++ b/athom-zigbee-gateway.yaml
@@ -1,15 +1,23 @@
 substitutions:
+  # Default name
   name: "athom-zigbee-gateway"
+  # Default friendly name   
   friendly_name: "Athom Zigbee Gateway"
+  # Allows ESP device to be automatically linked to an 'Area' in Home Assistant. Typically used for areas such as 'Lounge Room', 'Kitchen' etc  
   room: ""
+  # Description as appears in ESPHome & top of webserver page
   device_description: "athom eth zigbee gateway"
+  # Project Name
   project_name: "Athom Technology.Athom Zigbee Gateway"
-  project_version: "v2.0.1"
-  dns_domain: ""
+  # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
+  project_version: "v2.0.2"
+  # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
+  dns_domain: ".local"
+  # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney") 
   timezone: ""
   # Define logging level: NONE, ERROR, WARN, INFO, DEBUG (Default), VERBOSE, VERY_VERBOSE
   log_level: "DEBUG"
-  # wifi_fast_connect: "false"
+
 
 esphome:
   name: "${name}"


### PR DESCRIPTION
This is following reports that the default ESPHome behaviour of publishing the device DNS name as .local was not working in recent updates. To rectify this the substitution of dns_domain: "" has been updated to force this behaviour, whilst allowing users to modify the substitution themselves if needed, with the change to dns_domain: ".local"

See: https://github.com/athom-tech/athom-configs/issues/111