### PR TITLE
Add state_class=STATE_CLASS_TOTAL to bl0906 energy sensors

### DIFF
--- a/components/bl0906/sensor.py
+++ b/components/bl0906/sensor.py
@@ -115,6 +115,7 @@ CONFIG_SCHEMA = (
                                 accuracy_decimals=3,
                                 device_class=DEVICE_CLASS_ENERGY,
                                 unit_of_measurement=UNIT_KILOWATT_HOURS,
+                                state_class=STATE_CLASS_TOTAL,
                             ),
                             key=CONF_NAME,
                         ),


### PR DESCRIPTION
Resolves https://github.com/athom-tech/esp32-configs/issues/33

Allows Energy sensors to be used in the Energy dashboard in Home Assistant. They require the state_class to be set to either TOTAL or TOTAL_INCREASING

I'm taking a guess at this - from what I can tell, it _should_ work. I have no idea how to test it against my local 6CH Energy Monitor though. If anyone has a link to the docs or any other guide to running custom configs, I'd be willing to give it a go.