### PR TITLE
Fix typo in Energy Monitor x2 YAML

### DIFF
--- a/athom-energy-monitor-x2.yaml
+++ b/athom-energy-monitor-x2.yaml
@@ -214,7 +214,7 @@ sensor:
       internal: true
     total_power:
       name: 'Total_Power'
-      id: 'Tatal_Power'
+      id: 'Total_Power'
 
   - platform: copy
     name: 'Total_Energy'


### PR DESCRIPTION
While looking through YAMLs, I found this typo.. Tatal -> Total