### PR TITLE
Add bluetooth proxy support

### DIFF
--- a/athom-ld2450-sensor.yaml
+++ b/athom-ld2450-sensor.yaml
@@ -74,6 +74,13 @@ wifi:
 
 captive_portal:
 
+esp32_ble_tracker:
+  scan_parameters:
+    active: true
+
+bluetooth_proxy:
+  active: true
+
 esp32_improv:
   authorizer: none
 


### PR DESCRIPTION
Tested as working - based on instructions: https://esphome.io/components/bluetooth_proxy/

Reference implementation from similar device: https://github.com/EverythingSmartHome/everything-presence-lite/blob/main/common/bluetooth-base.yaml