### PR TITLE
Add id to SCD40 sensor

### DIFF
--- a/athom-scd40-sensor.yaml
+++ b/athom-scd40-sensor.yaml
@@ -137,6 +137,7 @@ i2c:
 # Example configuration entry
 sensor:
   - platform: scd4x
+    id: scd40_sensor
     update_interval: ${update_interval}
     co2:
       name: "CO2"


### PR DESCRIPTION
This allows local configs to extend the sensor config with `!extend` in order to add settings such as altitude compensation.