### PR TITLE
Add ID to climate entity in rf-ir-remote

### DIFF
--- a/athom-rf-ir-remote.yaml
+++ b/athom-rf-ir-remote.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom RF IR Remote"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.2"
+  project_version: "v3.0.3"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")

--- a/athom-rf-ir-remote.yaml
+++ b/athom-rf-ir-remote.yaml
@@ -227,9 +227,10 @@ radio_frequency:
     remote_receiver_id: rf_receiver
 
 climate:
-  - platform: ${AC_Platform_name}
-    transmitter_id: ir_transmitter
+  - id: "AC"
     name: "AC"
+    platform: ${AC_Platform_name}
+    transmitter_id: ir_transmitter
     receiver_id: ir_receiver
 
 binary_sensor:


### PR DESCRIPTION
# Change

Add an ID to the climate entity in the rf-ir-remote config

# Why?

I have an AC from Mitsubishi Heavy Industries. The esp32 climate component does not support this manufacturer directly (there is a `mitsubishi` platform, however this only supports ACs from Mitsubishi Electric - a different company). 

Mitsubishi Heavy Industries is supported by the Arduino HeatpumpIR library, which can be used with the esp32 climate component, however in order to use the `heatpumpir` platform additional configuration options must be set. In order to set these, I need to [extend](https://esphome.io/components/packages/#extend) the climate entity.

The problem is that `!extend` can only reference an entity by it's ID, and in this case an ID is not set, so I am unable to use this config with my AC.