### PR TITLE
Add ids to OTA platform entries in all device configs

### DIFF
--- a/athom-1gang-switch.yaml
+++ b/athom-1gang-switch.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.1Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.2"
+  project_version: "v3.0.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
@@ -114,6 +114,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -121,6 +122,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-1gang-switch.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-1gang-switch.yaml
+++ b/athom-1gang-switch.yaml
@@ -105,8 +105,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-2ch-relay-board.yaml
+++ b/athom-2ch-relay-board.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""
   device_description: "athom esp32 2ch relay board"
   project_name: "Athom Technology.ESP32 2CH Relay Board"
-  project_version: "v2.0.6"
+  project_version: "v2.0.7"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
@@ -90,6 +90,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -97,6 +98,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-2ch-relay-board.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-2ch-relay-board.yaml
+++ b/athom-2ch-relay-board.yaml
@@ -81,8 +81,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-2gang-switch.yaml
+++ b/athom-2gang-switch.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.2Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.2"
+  project_version: "v3.0.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
@@ -117,6 +117,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -124,6 +125,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-2gang-switch.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-2gang-switch.yaml
+++ b/athom-2gang-switch.yaml
@@ -108,8 +108,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-3gang-switch.yaml
+++ b/athom-3gang-switch.yaml
@@ -111,8 +111,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-3gang-switch.yaml
+++ b/athom-3gang-switch.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.3Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.2"
+  project_version: "v3.0.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
@@ -120,6 +120,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -127,6 +128,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-3gang-switch.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-4ch-relay-board.yaml
+++ b/athom-4ch-relay-board.yaml
@@ -83,8 +83,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-4ch-relay-board.yaml
+++ b/athom-4ch-relay-board.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""
   device_description: "athom esp32 4ch relay board"
   project_name: "Athom Technology.ESP32 4CH Relay Board"
-  project_version: "v2.0.6"
+  project_version: "v2.0.7"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
@@ -92,6 +92,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -99,6 +100,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-4ch-relay-board.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-4gang-switch.yaml
+++ b/athom-4gang-switch.yaml
@@ -114,8 +114,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-4gang-switch.yaml
+++ b/athom-4gang-switch.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.4Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.2"
+  project_version: "v3.0.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
@@ -123,6 +123,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -130,6 +131,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-4gang-switch.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-8ch-relay-board.yaml
+++ b/athom-8ch-relay-board.yaml
@@ -87,8 +87,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-8ch-relay-board.yaml
+++ b/athom-8ch-relay-board.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""
   device_description: "athom esp32 8ch relay board"
   project_name: "Athom Technology.ESP32 8CH Relay Board"
-  project_version: "v2.0.6"
+  project_version: "v2.0.7"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
@@ -96,6 +96,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -103,6 +104,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-8ch-relay-board.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-dual-smart-plug-v3.yaml
+++ b/athom-dual-smart-plug-v3.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: China Athom Technology.Athom Dual Plug V3
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: v3.0.1
+  project_version: v3.0.2
   # Restore the relay (GPO switch) upon reboot to state:
   relay1_restore_mode: RESTORE_DEFAULT_ON
   relay2_restore_mode: RESTORE_DEFAULT_ON
@@ -127,6 +127,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -134,6 +135,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-dual-smart-plug-v3.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-dual-smart-plug-v3.yaml
+++ b/athom-dual-smart-plug-v3.yaml
@@ -118,8 +118,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-energy-monitor-x2.yaml
+++ b/athom-energy-monitor-x2.yaml
@@ -85,8 +85,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-energy-monitor-x2.yaml
+++ b/athom-energy-monitor-x2.yaml
@@ -5,7 +5,7 @@ substitutions:
   room: ""
   device_description: "athom bl0906 energy meter (2 channels)"
   project_name: "Athom Technology.Athom Energy Meter(2 Channels)"
-  project_version: "3.0.2"
+  project_version: "3.0.3"
   update_interval: 5s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
@@ -94,6 +94,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -101,6 +102,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-energy-monitor-x2.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-energy-monitor-x6.yaml
+++ b/athom-energy-monitor-x6.yaml
@@ -5,7 +5,7 @@ substitutions:
   room: ""
   device_description: "athom bl0906 energy meter (6 channels)"
   project_name: "Athom Technology.Athom Energy Meter(6 Channels)"
-  project_version: "3.0.3"
+  project_version: "3.0.4"
   update_interval: 5s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
@@ -114,6 +114,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -121,6 +122,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-energy-monitor-x6.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-energy-monitor-x6.yaml
+++ b/athom-energy-monitor-x6.yaml
@@ -105,8 +105,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -80,8 +80,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Garage Door Opener"
   # Project version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.1.3"
+  project_version: "v3.1.4"
   # Status inverted
   status_inverted: "true"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
@@ -89,6 +89,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -96,6 +97,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-garage-door.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-ld2450-sensor.yaml
+++ b/athom-ld2450-sensor.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""
   device_description: "athom esp32c3 ld2450 motion target tracking sensor"
   project_name: "China Athom Technology.PS02C3MZ LD2450"
-  project_version: "v2.0.5"
+  project_version: "v2.0.6"
   update_interval: 60s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ""
@@ -75,6 +75,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -82,6 +83,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-ld2450-sensor.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-ld2450-sensor.yaml
+++ b/athom-ld2450-sensor.yaml
@@ -66,8 +66,10 @@ web_server:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-mini-relay-v2.yaml
+++ b/athom-mini-relay-v2.yaml
@@ -88,8 +88,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-mini-relay-v2.yaml
+++ b/athom-mini-relay-v2.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Mini Relay V2"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.1.1"
+  project_version: "v3.1.2"
    # Restore the relay (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_OFF
   # Set the update interval for sensors
@@ -97,6 +97,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -104,6 +105,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-mini-relay-v2.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-presence-sensor-v3.yaml
+++ b/athom-presence-sensor-v3.yaml
@@ -83,8 +83,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-presence-sensor-v3.yaml
+++ b/athom-presence-sensor-v3.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom PS01C3 Presence Sensor"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v4.0.1"
+  project_version: "v4.0.2"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
@@ -92,6 +92,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -99,6 +100,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-presence-sensor-v3.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-rf-ir-remote.yaml
+++ b/athom-rf-ir-remote.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom RF IR Remote"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.5"
+  project_version: "v3.0.6"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
@@ -136,6 +136,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -143,6 +144,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-rf-ir-remote.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-rf-ir-remote.yaml
+++ b/athom-rf-ir-remote.yaml
@@ -127,8 +127,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-rgbcw-bulb.yaml
+++ b/athom-rgbcw-bulb.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom RGBCW Bulb"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.2.3"
+  project_version: "v3.2.4"
    # Restore the light (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_ON
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
@@ -213,6 +213,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -220,6 +221,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-rgbcw-bulb.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-rgbcw-bulb.yaml
+++ b/athom-rgbcw-bulb.yaml
@@ -204,8 +204,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-rgbcw-light.yaml
+++ b/athom-rgbcw-light.yaml
@@ -204,8 +204,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-rgbcw-light.yaml
+++ b/athom-rgbcw-light.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom 12W RGBCW Bulb"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.1.5"
+  project_version: "v3.1.6"
    # Restore the light (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_ON
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
@@ -213,6 +213,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -220,6 +221,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-rgbcw-light.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-scd40-sensor.yaml
+++ b/athom-scd40-sensor.yaml
@@ -88,8 +88,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-scd40-sensor.yaml
+++ b/athom-scd40-sensor.yaml
@@ -5,7 +5,7 @@ substitutions:
   room: ""
   device_description: "athom scd40 CO₂ sensor"
   project_name: "China Athom Technology.CO₂ Sensor"
-  project_version: "1.0.9"
+  project_version: "1.0.10"
   update_interval: 5s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
@@ -97,6 +97,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -104,6 +105,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-scd40-sensor.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-sht40-sensor.yaml
+++ b/athom-sht40-sensor.yaml
@@ -5,7 +5,7 @@ substitutions:
   room: ""
   device_description: "athom sht40 temperature and humidity sensor"
   project_name: "China Athom Technology.Temperature Humidity Sensor"
-  project_version: "1.0.8"
+  project_version: "1.0.9"
   update_interval: 5s
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
@@ -102,6 +102,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -109,6 +110,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-sht40-sensor.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-sht40-sensor.yaml
+++ b/athom-sht40-sensor.yaml
@@ -93,8 +93,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-smart-plug-v5.yaml
+++ b/athom-smart-plug-v5.yaml
@@ -112,6 +112,7 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
 
 logger:
   baud_rate: 0  # 0 Enables logging, but disables serial-port logging to free CPU and memory

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom Plug V3"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v2.0.3"
+  project_version: "v2.0.4"
   # Restore the relay (GPO switch) upon reboot to state:
   relay_restore_mode: RESTORE_DEFAULT_ON
   # Set the update interval for sensors
@@ -124,6 +124,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -131,6 +132,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-smart-plug.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -115,8 +115,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-wall-outlet-v3.yaml
+++ b/athom-wall-outlet-v3.yaml
@@ -114,8 +114,10 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-wall-outlet-v3.yaml
+++ b/athom-wall-outlet-v3.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom Wall Outlet V3"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.2"
+  project_version: "v3.0.3"
   # Restore the relay (GPO switch) upon reboot to state:
   relay_restore_mode: RESTORE_DEFAULT_OFF
   # Set the update interval for sensors
@@ -123,6 +123,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -130,6 +131,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-wall-outlet-v3.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)

--- a/athom-zigbee-gateway.yaml
+++ b/athom-zigbee-gateway.yaml
@@ -105,8 +105,10 @@ logger:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   # Enables OTA firmware flashing from a URL (used by the update component below)
   - platform: http_request
+    id: ota_http_request
 
 # Required by the ota http_request platform and the update component.
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during

--- a/athom-zigbee-gateway.yaml
+++ b/athom-zigbee-gateway.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom Zigbee Gateway"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v2.0.9"
+  project_version: "v2.0.10"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney") 
@@ -114,6 +114,7 @@ ota:
 # verify_ssl: false skips TLS cert validation to reduce heap/RAM pressure during
 # the download; the manifest's MD5 still verifies firmware integrity before flashing.
 http_request:
+  id: http_request_component
   verify_ssl: false
 
 update:
@@ -121,6 +122,7 @@ update:
   # and exposes a "Firmware Update" entity, pointing at this device's GitHub Pages
   # manifest. Pages URLs avoid the redirect/buffer issues of Release download URLs.
   - platform: http_request
+    id: update_http_request
     name: "Firmware Update"
     source: https://athom-tech.github.io/esp32-configs/firmware/athom-zigbee-gateway.manifest.json
     # update_interval defaults to 6h (how often it checks, not installs)


### PR DESCRIPTION
## Summary
- Add explicit `id` fields to OTA platform entries across all 23 device YAML files
- `ota_esphome` and `ota_http_request` ids enable device-specific configs to reference and override these entries, e.g. to set an OTA password
- `athom-smart-plug-v5.yaml` only has the `esphome` platform, so it gets just `ota_esphome`

## Test plan
- [x] Manually test one confifg in latest esphome
- [x] Verify no duplicate-id warnings