### PR TITLE
Extend RF433 slots from 10 to 16

### DIFF
--- a/athom-rf-ir-remote.yaml
+++ b/athom-rf-ir-remote.yaml
@@ -89,7 +89,7 @@ globals:
     type: bool
     restore_value: no
     initial_value: 'false'
-  # RF433 slot index, offset to 10-19 so it never collides with IR slots 0-9
+  # RF433 slot index, offset to 10-25 so it never collides with IR slots 0-9
   - id: rf_signal_select_index
     type: int
     restore_value: yes
@@ -488,6 +488,12 @@ select:
       - "Signal 7"
       - "Signal 8"
       - "Signal 9"
+      - "Signal 10"
+      - "Signal 11"
+      - "Signal 12"
+      - "Signal 13"
+      - "Signal 14"
+      - "Signal 15"
     initial_option: "Signal 0"
     on_value:
       - lambda: |-
@@ -501,6 +507,12 @@ select:
           else if (x == "Signal 7") id(rf_signal_select_index) = 17;
           else if (x == "Signal 8") id(rf_signal_select_index) = 18;
           else if (x == "Signal 9") id(rf_signal_select_index) = 19;
+          else if (x == "Signal 10") id(rf_signal_select_index) = 20;
+          else if (x == "Signal 11") id(rf_signal_select_index) = 21;
+          else if (x == "Signal 12") id(rf_signal_select_index) = 22;
+          else if (x == "Signal 13") id(rf_signal_select_index) = 23;
+          else if (x == "Signal 14") id(rf_signal_select_index) = 24;
+          else if (x == "Signal 15") id(rf_signal_select_index) = 25;
           ESP_LOGI("RF_LEARNING", "Selected slot: %d", id(rf_signal_select_index));
 
 # Script for sending raw IR signals

--- a/athom-rf-ir-remote.yaml
+++ b/athom-rf-ir-remote.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "China Athom Technology.Athom RF IR Remote"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v3.0.5"
+  project_version: "v3.0.6"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
   dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")


### PR DESCRIPTION
I recently bought an IR/RF from you and I am setting it up. I want to control four RF433 blinds/covers. Each one has three commands (open, stop, close). Therefore I need a total of 12 RF slots. The firmware currently accepts 10 RF slots. 

This PR adds Signal 10-15 to the RF Signal Slot dropdown and the matching NVS index mapping (20-25), continuing the existing 10-19 offset scheme so RF slots stay disjoint from IR slots (0-9). IR slot count is unchanged.

According to Claude, an RF slot takes less memory than an IR slot. I have kept the IR slots at 10 since I don't have the need for more.

Would you please consider reviewing and merging this PR?

Thank you